### PR TITLE
Allow additional preview host

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,6 @@ export default defineConfig({
     },
   },
   preview: {
-    allowedHosts: ['vectra-v734a.ondigitalocean.app'],
+    allowedHosts: ['vectra-v734a.ondigitalocean.app', 'vectra-open-tkq6e.ondigitalocean.app'],
   },
 });


### PR DESCRIPTION
## Summary
- allow vectra-open-tkq6e.ondigitalocean.app in Vite preview allowedHosts

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1b84ff35c8328991de1d99c2130ee