### PR TITLE
Add interactive map start and destination selection

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -375,6 +375,22 @@ body,html,#root {
   cursor: not-allowed;
 }
 
+.coord-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.coord-group.highlight input {
+  border-color: #f7931e;
+}
+
+.remove-btn {
+  align-self: flex-start;
+  padding: 4px 6px;
+  font-size: 12px;
+}
+
 .dialog h3 {
   margin-top: 0;
   color: #f7931e;


### PR DESCRIPTION
## Summary
- Use first map double-click to capture start coordinates and second for destination
- Display markers and a dotted line connecting start and destination
- Highlight next inputs and allow clearing selections from the flights overlay

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1cd2b6afc8328b4446413583502df