### PR TITLE
Fix manual flight planning double-click behavior

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -278,6 +278,7 @@ export default function App() {
       }
       setMapLoaded(true);
       applyMapMode(mapMode);
+      mapRef.current.doubleClickZoom.disable();
     });
   }, [mapStyleIndex]);
 
@@ -286,7 +287,7 @@ export default function App() {
   }, [isDark]);
 
   useEffect(() => {
-    if (!mapRef.current) return;
+    if (!mapRef.current || !mapLoaded) return;
     const map = mapRef.current;
     const handler = e => {
       const { lng, lat } = e.lngLat;
@@ -301,7 +302,7 @@ export default function App() {
     map.on('dblclick', handler);
     map.doubleClickZoom.disable();
     return () => map.off('dblclick', handler);
-  }, [manualStartLat, manualStartLng]);
+  }, [manualStartLat, manualStartLng, mapLoaded]);
 
   useEffect(() => {
     if (!mapRef.current || !mapLoaded) return;


### PR DESCRIPTION
## Summary
- disable double-click zoom when map loads
- reattach double-click handler once the map finishes loading so start and destination points can be set

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b55e100fd483289167d335915a15d4