### PR TITLE
Fix reference error from late imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Vectra Open Source
+
+This project is a React application built with Vite.
+
+## Development
+
+- `npm run dev` – start development server
+- `npm run build` – create production build
+- `npm run preview` – preview the build locally
+
+## Recent changes
+
+- Fixed a build-time reference error by ensuring all module imports are evaluated before usage in `src/utils.js`.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,9 @@
 // utils.js
 import { OverpassFetcher } from './overpassfetcher.js';
 import { lonLatToPixelXY, pixelXYToLonLat } from './geo.js';
+import simplify from '@turf/simplify';
+import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
+import { point as turfPoint, polygon as turfPolygon } from '@turf/helpers';
 
 let dockingStationAltitudeInMeters = 0;
 let cruiseAltitudeInMeters = 90;
@@ -28,7 +31,6 @@ let gustWindSpeedLimitInMetersPerSecond = 20;
 let groundSpeedToDestinationInMetersPerSecond = 13;
 let groundSpeedToHomeInMetersPerSecond = 8.5;
 const overpass = new OverpassFetcher(300); // radius in meters
-import simplify from '@turf/simplify';
 
 export function simplifyFeatureGeometry(feature, toleranceMeters = 100) {
     try {
@@ -521,9 +523,6 @@ export function getEstimatedTimeRequiredBetweenTakeOffAndArrivalAtDestinationInM
 export function getEstimatedMissionTimeAtWhichDroneShouldReturnInMinutes(distance) {
     return calculateTakeoffToCruise() + calculateCruisePhaseToDestination(distance) + calculateTimeOnStation(distance);
 }
-
-import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
-import { point as turfPoint, polygon as turfPolygon } from '@turf/helpers';
 
 function pointInPolygon([lon, lat], geometry) {
     if (!geometry) return false;


### PR DESCRIPTION
## Summary
- Ensure utility module imports are loaded before usage to prevent runtime ReferenceError
- Document build and run commands

## Testing
- `npm test`
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68b59587bd748328a7ce712648069d45