### PR TITLE
fix: add JS entry for AuthDialog

### DIFF
--- a/src/AuthDialog.js
+++ b/src/AuthDialog.js
@@ -1,0 +1,1 @@
+export { default } from './AuthDialog.jsx';


### PR DESCRIPTION
## Summary
- add JS entry file for AuthDialog so extensionless imports resolve

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b59a240af48328992072c9d13ca4d7