### PR TITLE
fix: reorder imports to ensure Zn initialization

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,9 @@
 // utils.js
-import { OverpassFetcher } from './overpassfetcher.js';
-import { lonLatToPixelXY, pixelXYToLonLat } from './geo.js';
 import simplify from '@turf/simplify';
 import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import { point as turfPoint, polygon as turfPolygon } from '@turf/helpers';
+import { OverpassFetcher } from './overpassfetcher.js';
+import { lonLatToPixelXY, pixelXYToLonLat } from './geo.js';
 
 let dockingStationAltitudeInMeters = 0;
 let cruiseAltitudeInMeters = 90;
@@ -524,7 +524,7 @@ export function getEstimatedMissionTimeAtWhichDroneShouldReturnInMinutes(distanc
     return calculateTakeoffToCruise() + calculateCruisePhaseToDestination(distance) + calculateTimeOnStation(distance);
 }
 
-function pointInPolygon([lon, lat], geometry) {
+export function pointInPolygon([lon, lat], geometry) {
     if (!geometry) return false;
     const pt = turfPoint([lon, lat]);
 


### PR DESCRIPTION
## Summary
- move turf imports to the top of `utils.js`
- export `pointInPolygon` helper to guarantee turf utilities load

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5a88f0bd88328b3ce15f13e92922a