### PR TITLE
Improve light mode overlay readability

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -19,6 +19,11 @@ body,html,#root {
   box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.18);
 }
 
+body.light .glass-effect {
+  background: rgba(255, 255, 255, 0.8);
+  border: 1.5px solid rgba(0, 0, 0, 0.13);
+}
+
 .top-right {
   position: absolute;
   top: 20px;
@@ -36,6 +41,10 @@ body,html,#root {
   cursor: pointer;
   font-size: 14px;
   position: relative;
+}
+body.light .top-right button,
+body.light .kp-pill {
+  color: #000;
 }
 
 .top-right button:disabled,


### PR DESCRIPTION
## Summary
- lighten glass-effect overlay background in light theme for better readability
- adjust top-right button text colors in light mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e69e29c08328a1e9f9506c8c92fe