### PR TITLE
fix: initialize flight path state before useMemo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -178,6 +178,7 @@ export default function App() {
   const [startLngError, setStartLngError] = useState('');
   const [latError, setLatError] = useState('');
   const [lngError, setLngError] = useState('');
+  const [flightPath, setFlightPath] = useState([]);
 
   const flightInfo = useMemo(() => {
     if (flightPath.length < 2 || !selected) return null;
@@ -276,7 +277,6 @@ export default function App() {
   const initialLayerIdsRef = useRef([]);
   const [layerFeatures, setLayerFeatures] = useState([]);
   const [routeNoFlyZones, setRouteNoFlyZones] = useState([]);
-  const [flightPath, setFlightPath] = useState([]);
   const [clearedZoneIds, setClearedZoneIds] = useState([]);
   const [mapLoaded, setMapLoaded] = useState(false);
   const [showWeather, setShowWeather] = useState(false);


### PR DESCRIPTION
## Summary
- initialize `flightPath` state before computing `flightInfo`
- remove redundant `flightPath` state declaration

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8035e97888328940544a07fe23c51