### PR TITLE
feat: highlight loaded NFZs with orange border

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -668,6 +668,8 @@ body.light .nfz-popup-nav button {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 6px;
+  border-left: 4px solid #f7931e;
+  padding-left: 6px;
 }
 
 .nfz-item button {


### PR DESCRIPTION
## Summary
- add orange left border and padding to loaded NFZ items for better visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b80bd53c2083288284da5577635517