### PR TITLE
Avoid using cleared zones in flight path

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -636,9 +636,8 @@ export default function App() {
     setRouteNoFlyZones(zones => zones.filter(z => getZoneId(z) !== id));
     const newCleared = [...clearedZoneIds, id];
     setClearedZoneIds(newCleared);
-    if (selected) {
-      focusDestination(selected, newCleared);
-    }
+    // focusDestination will be triggered by the clearedZoneIds effect,
+    // ensuring cleared zones are excluded from the flight path
   }
 
   function applyMapMode(mode) {


### PR DESCRIPTION
## Summary
- Remove immediate focus recalculation when clearing no-fly zones so the flight path ignores cleared zones.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b979bc1e548328b6a87435fdb35c6a