### PR TITLE
Remove KP value from flight calculator overlay

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1294,19 +1294,6 @@ export default function App() {
                 {flightInfo.flight.returnGroundSpeed?.toFixed(1)} m/s
               </span>
             </div>
-            {kpData && (
-              <div className="info-row">
-                <span className="label">KP</span>
-                <span className={`value ${kpData.kp < 5 ? 'ok' : 'no'}`}>
-                  {kpData.kp < 5 ? (
-                    <SealCheck size={16} weight="fill" />
-                  ) : (
-                    <SealWarning size={16} weight="fill" />
-                  )}
-                  {kpData.kp}
-                </span>
-              </div>
-            )}
           </div>
 
           {routeNoFlyZones.length > 0 && (


### PR DESCRIPTION
## Summary
- hide KP index row from flight calculator overlay so users don't see KP value

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b979a2457c83288355f3cadbfecef8