### PR TITLE
Use airplane icon for flights menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,8 @@ import {
   Cloud,
   SealCheck,
   SealWarning,
-  ChatCenteredText
+  ChatCenteredText,
+  Airplane
 } from '@phosphor-icons/react';
 import FeedbackDialog from './FeedbackDialog';
 import { isZoneActive } from './fetchActiveGeozones.js';
@@ -1182,7 +1183,7 @@ export default function App() {
           aria-label="Flights"
           title="Flights"
         >
-          <Globe size={18} />
+          <Airplane size={18} />
         </button>
         <button
           className="glass-effect"


### PR DESCRIPTION
## Summary
- replace flights menu globe icon with airplane for clearer navigation imagery

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b980fc75d48328866eafb890596804