### PR TITLE
Fix multipolygon no-fly zone detection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -254,15 +254,7 @@ function calculateAvoidingPath(start, dest, zones = []) {
   }
 
   // Start with zones intersecting the direct path
-  const direct = lineString([start, dest]);
-  let considered = zones.filter(z => {
-    const geom = z.geometry;
-    if (!geom) return false;
-    const poly =
-      geom.type === 'Polygon' || geom.type === 'MultiPolygon' ? geom : null;
-    if (!poly) return false;
-    return lineIntersect(direct, poly).features.length > 0;
-  });
+  let considered = zones.filter(z => pathIntersectsZone([start, dest], z));
 
   let path = [start, dest];
   let explored = [];


### PR DESCRIPTION
## Summary
- ensure direct-path zone filtering uses full path intersection logic

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b990a8a5d08328a950dbc7ec9af1b9