### PR TITLE
Fix layer button styles for light mode

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -163,6 +163,10 @@ body.light .kp-pill {
   background: #262626;
 }
 
+body.light .dialog li:hover {
+  background: #eee;
+}
+
 .dialog li.near {
   border-left-color: #4caf50;
 }
@@ -218,6 +222,20 @@ body.light .kp-pill {
   font-size: 12px;
   margin-top: 2px;
   color: #fff;
+}
+
+body.light .dest-btn {
+  background: #fff;
+  color: #000;
+}
+
+body.light .dest-btn:hover {
+  background: #eee;
+}
+
+body.light .dest-btn.active {
+  background: #f7931e;
+  color: #000;
 }
 
 /* Flights panel */


### PR DESCRIPTION
## Summary
- Ensure layer list hover states use light backgrounds in light mode
- Style layer buttons with light backgrounds, hover, and active colors when light mode is enabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb383749cc83288f7c0c767a5d6bd2