### PR TITLE
feat: persist map style

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -357,6 +357,31 @@ export default function App() {
   const [showWeather, setShowWeather] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
 
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('mapStyle');
+      if (saved) {
+        const index = MAP_STYLES.findIndex(s => s.key === saved);
+        if (index >= 0) {
+          setMapStyleIndex(index);
+        }
+      }
+    } catch (e) {
+      console.error('Failed to read saved map style', e);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      const key = MAP_STYLES[mapStyleIndex]?.key;
+      if (key) {
+        localStorage.setItem('mapStyle', key);
+      }
+    } catch (e) {
+      console.error('Failed to save map style', e);
+    }
+  }, [mapStyleIndex]);
+
   const currentStyle = MAP_STYLES[mapStyleIndex];
   const isDark = currentStyle.isDark;
   const nextStyle = MAP_STYLES[(mapStyleIndex + 1) % MAP_STYLES.length];


### PR DESCRIPTION
## Summary
- store selected map style (dark, light, satellite) in localStorage
- restore saved map style on startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb38cd1a60832888e0293370cde16b