### PR TITLE
Improve light mode readability for flight inputs

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -144,6 +144,10 @@ body.light .kp-pill {
   scrollbar-color: #555 #222;
 }
 
+body.light .dialog {
+  color: #000;
+}
+
 .dialog ul {
   list-style: none;
   padding: 0;
@@ -181,6 +185,16 @@ body.light .kp-pill {
   border-radius: 4px;
   cursor: pointer;
   transition: background 0.2s;
+}
+
+body.light .dialog button {
+  background: #eee;
+  color: #000;
+  border: 1px solid #ccc;
+}
+
+body.light .dialog button:hover:not(:disabled) {
+  background: #ddd;
 }
 
 .dest-btn {
@@ -242,6 +256,12 @@ body.light .kp-pill {
   padding: 4px;
 }
 
+body.light .flights-header select {
+  background: #fff;
+  color: #000;
+  border: 1px solid #ccc;
+}
+
 .flights-panel ul {
   list-style: none;
   padding: 0;
@@ -258,6 +278,10 @@ body.light .kp-pill {
   font-size: 12px;
   margin: 4px 0;
   color: #ccc;
+}
+
+body.light .manual-description {
+  color: #555;
 }
 
 .flight-btn {
@@ -349,6 +373,10 @@ body.light .kp-pill {
   font-size: 12px;
 }
 
+body.light .manual-entry label {
+  color: #000;
+}
+
 .manual-entry input {
   margin-top: 4px;
   width: 100%;
@@ -358,6 +386,16 @@ body.light .kp-pill {
   border: 1px solid #555;
   border-radius: 4px;
   color: #fff;
+}
+
+body.light .manual-entry input {
+  background: #fff;
+  border: 1px solid #ccc;
+  color: #000;
+}
+
+body.light .manual-entry input::placeholder {
+  color: #555;
 }
 
 .manual-entry .error {
@@ -377,6 +415,10 @@ body.light .kp-pill {
 
 .manual-entry button:hover:not(:disabled) {
   background: #444;
+}
+
+body.light .manual-entry button:hover:not(:disabled) {
+  background: #ddd;
 }
 
 .manual-entry button:disabled {


### PR DESCRIPTION
## Summary
- use dark text for dialogs and buttons in light/satellite modes
- restyle flight inputs with light backgrounds and dark text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb390e6394832899dca5922b9070bf