### PR TITLE
Skip RRT when direct route avoids NFZs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -148,6 +148,13 @@ function calculateAvoidingPath(start, dest, zones = []) {
     return zones.some(z => pathIntersectsZone([a, b], z));
   }
 
+  // quick check for a direct straight path before running RRT
+  const straightPath = [start, dest];
+  const directIntersections = zones.filter(z => pathIntersectsZone(straightPath, z));
+  if (directIntersections.length === 0) {
+    return { path: straightPath, intersected: [], explored: [] };
+  }
+
   let minLng = Math.min(start[0], dest[0]);
   let minLat = Math.min(start[1], dest[1]);
   let maxLng = Math.max(start[0], dest[0]);


### PR DESCRIPTION
## Summary
- Short-circuit path planning when no-fly zones don't intersect the direct start-destination line
- Return direct path with empty metadata to render straight routes without NFZs

## Testing
- `node` *(manual check of calculateAvoidingPath with no zones)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be8164635c83289b3d8fa04e59064c