### PR TITLE
refactor: expose path intersection helpers with early exit

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -131,19 +131,19 @@ function generateHoverCircle(center, radiusMeters = 50, points = 60) {
 
 }
 
-function calculateAvoidingPath(start, dest, zones = []) {
-  // Helper that checks whether a path intersects a given zone
-  function pathIntersectsZone(path, zone) {
-    const geom = zone.geometry;
-    if (!geom) return false;
-    const poly =
-      geom.type === 'Polygon' || geom.type === 'MultiPolygon' ? geom : null;
-    if (!poly) return false;
-    const line = lineString(path);
-    if (lineIntersect(line, polygonToLine(poly)).features.length > 0) return true;
-    return path.some(c => booleanPointInPolygon(point(c), poly));
-  }
+// Helper that checks whether a path intersects a given zone
+export function pathIntersectsZone(path, zone) {
+  const geom = zone.geometry;
+  if (!geom) return false;
+  const poly =
+    geom.type === 'Polygon' || geom.type === 'MultiPolygon' ? geom : null;
+  if (!poly) return false;
+  const line = lineString(path);
+  if (lineIntersect(line, polygonToLine(poly)).features.length > 0) return true;
+  return path.some(c => booleanPointInPolygon(point(c), poly));
+}
 
+export function calculateAvoidingPath(start, dest, zones = []) {
   function segmentIntersects(a, b) {
     return zones.some(z => pathIntersectsZone([a, b], z));
   }

--- a/src/pathfinding.test.jsx
+++ b/src/pathfinding.test.jsx
@@ -1,0 +1,146 @@
+import { vi, describe, test, expect } from 'vitest';
+import { calculateAvoidingPath, pathIntersectsZone } from './App.jsx';
+
+vi.mock('mapbox-gl', () => {
+  class Map {
+    constructor() {
+      this.doubleClickZoom = { disable() {} };
+    }
+    on() {}
+    remove() {}
+    getSource() {
+      return { setData() {} };
+    }
+    addSource() {}
+    addLayer() {}
+    fitBounds() {}
+    stop() {}
+    getStyle() {
+      return { layers: [] };
+    }
+    setTerrain() {}
+    removeLayer() {}
+    removeSource() {}
+    easeTo() {}
+    getCanvas() {
+      return { style: {} };
+    }
+    isStyleLoaded() {
+      return true;
+    }
+    getCenter() {
+      return { lng: 0, lat: 0 };
+    }
+    getZoom() {
+      return 0;
+    }
+    queryRenderedFeatures() {
+      return [];
+    }
+    off() {}
+  }
+  class Popup {
+    setLngLat() {
+      return this;
+    }
+    addTo() {
+      return this;
+    }
+    addClassName() {
+      return this;
+    }
+    setHTML() {
+      return this;
+    }
+    remove() {}
+  }
+  class Marker {
+    setLngLat() {
+      return this;
+    }
+    addTo() {
+      return this;
+    }
+    remove() {}
+  }
+  return { Map, Popup, Marker, default: { Map, Popup, Marker } };
+});
+
+describe('pathIntersectsZone', () => {
+  const polygon = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'Polygon',
+      coordinates: [[[0, 0],[0, 0.01],[0.01, 0.01],[0.01, 0],[0, 0]]]
+    }
+  };
+  const multipolygon = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'MultiPolygon',
+      coordinates: [
+        [[[0, 0],[0, 0.01],[0.01, 0.01],[0.01, 0],[0, 0]]],
+        [[[0.02, 0],[0.02, 0.01],[0.03, 0.01],[0.03, 0],[0.02, 0]]]
+      ]
+    }
+  };
+
+  test('detects intersections for Polygon', () => {
+    expect(pathIntersectsZone([[-0.01, -0.01], [0.005, 0.005]], polygon)).toBe(true);
+    expect(pathIntersectsZone([[0.02, 0.02], [0.03, 0.03]], polygon)).toBe(false);
+  });
+
+  test('detects intersections for MultiPolygon', () => {
+    expect(pathIntersectsZone([[-0.01, -0.01], [0.025, 0.005]], multipolygon)).toBe(true);
+    expect(pathIntersectsZone([[-0.01, -0.01], [-0.02, -0.02]], multipolygon)).toBe(false);
+  });
+});
+
+describe('calculateAvoidingPath', () => {
+  const polygon = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'Polygon',
+      coordinates: [[[0, 0],[0, 0.01],[0.01, 0.01],[0.01, 0],[0, 0]]]
+    }
+  };
+  const multipolygon = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'MultiPolygon',
+      coordinates: [
+        [[[0, 0],[0, 0.01],[0.01, 0.01],[0.01, 0],[0, 0]]],
+        [[[0.02, 0],[0.02, 0.01],[0.03, 0.01],[0.03, 0],[0.02, 0]]]
+      ]
+    }
+  };
+
+  test('returns straight path when no intersection', () => {
+    const start = [-0.01, -0.01];
+    const dest = [-0.02, -0.02];
+    const { path } = calculateAvoidingPath(start, dest, [polygon]);
+    expect(path).toEqual([start, dest]);
+  });
+
+  test('detours when route crosses Polygon zone', () => {
+    const start = [-0.005, 0.005];
+    const dest = [0.015, 0.005];
+    expect(pathIntersectsZone([start, dest], polygon)).toBe(true);
+    const { path } = calculateAvoidingPath(start, dest, [polygon]);
+    expect(path.length).toBeGreaterThan(2);
+    expect(pathIntersectsZone(path, polygon)).toBe(false);
+  });
+
+  test('detours when route crosses MultiPolygon zone', () => {
+    const start = [0.015, 0.005];
+    const dest = [0.035, 0.005];
+    expect(pathIntersectsZone([start, dest], multipolygon)).toBe(true);
+    const { path } = calculateAvoidingPath(start, dest, [multipolygon]);
+    expect(path.length).toBeGreaterThan(2);
+    expect(pathIntersectsZone(path, multipolygon)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- expose `pathIntersectsZone` helper and use it to skip RRT when the straight path is clear
- handle Polygon and MultiPolygon features from `layerFeaturesRef`
- add tests covering path intersection and detours around NFZ polygons

## Testing
- `npx vitest run --environment jsdom`

------
https://chatgpt.com/codex/tasks/task_e_68be85166b00832899ca067e8d0ac158