### PR TITLE
Disable right-click drag rotation on map

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -491,6 +491,7 @@ export default function App(
       setMapLoaded(true);
       applyMapMode(mapMode);
       mapRef.current.doubleClickZoom.disable();
+      mapRef.current.dragRotate && mapRef.current.dragRotate.disable();
     });
   }, [mapStyleIndex]);
 


### PR DESCRIPTION
## Summary
- prevent 3D map panning via right-click drag by disabling Mapbox's dragRotate control

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bed852f1408328b60ea874b2044eb5