### PR TITLE
Clear manual inputs on mission reset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -324,8 +324,11 @@ export default function App(
   }
 
   function resetMission() {
+    // Clear any active mission and remove associated map overlays
     setSelected(null);
     setFlightPath([]);
+    clearStart();
+    clearDestination();
     const map = mapRef.current;
     if (map) {
       if (map.getLayer('flight')) map.removeLayer('flight');


### PR DESCRIPTION
## Summary
- Ensure resetMission clears manual start and destination fields so overlays disappear when resetting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf12d0692c8328a6db92edfe8dc8b6