### PR TITLE
Align mission controls with emphasis on Go

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1619,41 +1619,44 @@ export default function App(
                 </p>
               )}
             </div>
-            <button
-              onClick={() => {
-                const sLat = parseFloat(manualStartLat);
-                const sLng = parseFloat(manualStartLng);
-                const dLat = parseFloat(manualLat);
-                const dLng = parseFloat(manualLng);
-                if (
-                  !isNaN(sLat) &&
-                  !isNaN(sLng) &&
-                  !isNaN(dLat) &&
-                  !isNaN(dLng) &&
-                  !startLatError &&
-                  !startLngError &&
-                  !latError &&
-                  !lngError
-                ) {
-                  setManualRoute(sLat, sLng, dLat, dLng);
+            <div className="manual-buttons">
+              <button
+                className="go-btn"
+                onClick={() => {
+                  const sLat = parseFloat(manualStartLat);
+                  const sLng = parseFloat(manualStartLng);
+                  const dLat = parseFloat(manualLat);
+                  const dLng = parseFloat(manualLng);
+                  if (
+                    !isNaN(sLat) &&
+                    !isNaN(sLng) &&
+                    !isNaN(dLat) &&
+                    !isNaN(dLng) &&
+                    !startLatError &&
+                    !startLngError &&
+                    !latError &&
+                    !lngError
+                  ) {
+                    setManualRoute(sLat, sLng, dLat, dLng);
+                  }
+                }}
+                disabled={
+                  !!startLatError ||
+                  !!startLngError ||
+                  !!latError ||
+                  !!lngError ||
+                  manualStartLat === '' ||
+                  manualStartLng === '' ||
+                  manualLat === '' ||
+                  manualLng === ''
                 }
-              }}
-              disabled={
-                !!startLatError ||
-                !!startLngError ||
-                !!latError ||
-                !!lngError ||
-                manualStartLat === '' ||
-                manualStartLng === '' ||
-                manualLat === '' ||
-                manualLng === ''
-              }
-            >
-              Go
-            </button>
-            <button className="remove-btn" onClick={resetMission}>
-              Reset Mission
-            </button>
+              >
+                Go
+              </button>
+              <button className="remove-btn" onClick={resetMission}>
+                Reset Mission
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/style.css
+++ b/src/style.css
@@ -460,6 +460,27 @@ body.light .manual-entry button:hover:not(:disabled) {
   font-size: 12px;
 }
 
+.manual-buttons {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  align-self: flex-start;
+}
+
+.manual-buttons .go-btn {
+  background: #f7931e;
+  color: #000;
+  font-weight: bold;
+}
+
+.manual-buttons .go-btn:hover:not(:disabled) {
+  background: #ffa94d;
+}
+
+.manual-buttons .remove-btn {
+  align-self: center;
+}
+
 .dialog h3 {
   margin-top: 0;
   color: #f7931e;


### PR DESCRIPTION
## Summary
- Display "Go" and "Reset Mission" buttons side by side
- Highlight "Go" button to draw emphasis

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bf126ad61483289dd8359b9b81d941