### PR TITLE
Improve detour logic for flight path avoidance

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,18 +14,9 @@ import {
 } from '@phosphor-icons/react';
 import FeedbackDialog from './FeedbackDialog';
 import { isZoneActive } from './fetchActiveGeozones.js';
-import {
-  lineString,
-  lineIntersect,
-  bbox,
-  point,
-  booleanPointInPolygon,
-  polygonToLine,
-  length,
-  flattenEach,
-  nearestPointOnLine,
-  centroid
-} from '@turf/turf';
+import { bbox } from '@turf/turf';
+import { calculateAvoidingPath } from './pathfinding.js';
+export { pathIntersectsZone } from './pathfinding.js';
 import {
   estimateActualDistance,
   getFlightGoNoGo,
@@ -134,80 +125,6 @@ function generateHoverCircle(center, radiusMeters = 50, points = 60) {
 
 }
 
-// Helper that checks whether a path intersects a given zone
-export function pathIntersectsZone(path, zone) {
-  const geom = zone.geometry;
-  if (!geom) return false;
-  const poly =
-    geom.type === 'Polygon' || geom.type === 'MultiPolygon' ? geom : null;
-  if (!poly) return false;
-  const line = lineString(path);
-  const intersections = lineIntersect(line, polygonToLine(poly)).features;
-  const filtered = intersections.filter(f => {
-    const [x, y] = f.geometry.coordinates;
-    return !path.some(p => Math.abs(p[0] - x) < 1e-9 && Math.abs(p[1] - y) < 1e-9);
-  });
-  if (filtered.length > 0) return true;
-  return path.some(c => booleanPointInPolygon(point(c), poly));
-}
-
-function findSegmentIndex(ring, pt) {
-  return nearestPointOnLine(lineString(ring), point(pt)).properties.index;
-}
-
-function buildPath(ring, startIdx, endIdx, direction) {
-  const res = [];
-  const len = ring.length - 1;
-  let idx = startIdx;
-  while (idx !== endIdx) {
-    idx = (idx + direction + len) % len;
-    res.push(ring[idx]);
-  }
-  return res;
-}
-
-export function calculateAvoidingPath(start, dest, zones = []) {
-  let path = [start, dest];
-
-  zones.forEach(zone => {
-    flattenEach(zone, poly => {
-      const ring = poly.geometry.coordinates[0];
-      const center = centroid(poly).geometry.coordinates;
-      const nudge = pt => {
-        const dx = pt[0] - center[0];
-        const dy = pt[1] - center[1];
-        const len = Math.sqrt(dx * dx + dy * dy) || 1;
-        const off = 1e-6;
-        return [pt[0] + (dx / len) * off, pt[1] + (dy / len) * off];
-      };
-      let i = 0;
-      while (i < path.length - 1) {
-        const a = path[i];
-        const b = path[i + 1];
-        const line = lineString([a, b]);
-        const ints = lineIntersect(line, polygonToLine(poly)).features;
-        if (ints.length >= 2) {
-          const p1 = ints[0].geometry.coordinates;
-          const p2 = ints[ints.length - 1].geometry.coordinates;
-          const sIdx = findSegmentIndex(ring, p1);
-          const eIdx = findSegmentIndex(ring, p2);
-          const cw = [p1, ...buildPath(ring, sIdx, eIdx, 1), p2].map(nudge);
-          const ccw = [p1, ...buildPath(ring, sIdx, eIdx, -1), p2].map(nudge);
-          const cwLen = length(lineString(cw));
-          const ccwLen = length(lineString(ccw));
-          const detour = cwLen < ccwLen ? cw : ccw;
-          path.splice(i + 1, 1, ...detour, b);
-          i += detour.length;
-        } else {
-          i++;
-        }
-      }
-    });
-  });
-
-  const intersected = zones.filter(z => pathIntersectsZone(path, z));
-  return { path, intersected, explored: [] };
-}
 
 export default function App(
   {

--- a/src/pathfinding.js
+++ b/src/pathfinding.js
@@ -1,0 +1,95 @@
+import { lineString, lineIntersect, polygonToLine, booleanPointInPolygon, point, length, flattenEach, nearestPointOnLine, centroid } from '@turf/turf';
+
+export function pathIntersectsZone(path, zone) {
+  const geom = zone.geometry;
+  if (!geom) return false;
+  const poly =
+    geom.type === 'Polygon' || geom.type === 'MultiPolygon' ? geom : null;
+  if (!poly) return false;
+  const line = lineString(path);
+  const intersections = lineIntersect(line, polygonToLine(poly)).features;
+  const filtered = intersections.filter(f => {
+    const [x, y] = f.geometry.coordinates;
+    return !path.some(p => Math.abs(p[0] - x) < 1e-9 && Math.abs(p[1] - y) < 1e-9);
+  });
+  if (filtered.length > 0) return true;
+  return path.some(c => booleanPointInPolygon(point(c), poly));
+}
+
+function findSegmentIndex(ring, pt) {
+  return nearestPointOnLine(lineString(ring), point(pt)).properties.index;
+}
+
+function buildPath(ring, startIdx, endIdx, direction) {
+  const res = [];
+  const len = ring.length - 1;
+  let idx = startIdx;
+  while (idx !== endIdx) {
+    idx = (idx + direction + len) % len;
+    res.push(ring[idx]);
+  }
+  return res;
+}
+
+export function calculateAvoidingPath(start, dest, zones = []) {
+  let path = [start, dest];
+  const maxIterations = 5;
+  let iter = 0;
+
+  while (iter < maxIterations) {
+    let changed = false;
+
+    zones.forEach(zone => {
+      flattenEach(zone, poly => {
+        const ring = poly.geometry.coordinates[0];
+        const center = centroid(poly).geometry.coordinates;
+        const nudge = pt => {
+          const dx = pt[0] - center[0];
+          const dy = pt[1] - center[1];
+          const len = Math.sqrt(dx * dx + dy * dy) || 1;
+          const off = 1e-6;
+          return [pt[0] + (dx / len) * off, pt[1] + (dy / len) * off];
+        };
+
+        let i = 0;
+        while (i < path.length - 1) {
+          const a = path[i];
+          const b = path[i + 1];
+          const line = lineString([a, b]);
+          let ints = lineIntersect(line, polygonToLine(poly)).features.map(f => f.geometry.coordinates);
+
+          if (booleanPointInPolygon(point(a), poly)) ints.unshift(a);
+          if (booleanPointInPolygon(point(b), poly)) ints.push(b);
+
+          if (ints.length >= 2) {
+            const p1 = ints[0];
+            const p2 = ints[ints.length - 1];
+            const sIdx = findSegmentIndex(ring, p1);
+            const eIdx = findSegmentIndex(ring, p2);
+            const cw = [p1, ...buildPath(ring, sIdx, eIdx, 1), p2].map(nudge);
+            const ccw = [p1, ...buildPath(ring, sIdx, eIdx, -1), p2].map(nudge);
+            const cwLen = length(lineString(cw));
+            const ccwLen = length(lineString(ccw));
+            const detour = cwLen < ccwLen ? cw : ccw;
+            path.splice(i + 1, 1, ...detour, b);
+            i += detour.length;
+            changed = true;
+          } else {
+            i++;
+          }
+        }
+      });
+    });
+
+    if (!changed) break;
+    iter++;
+  }
+
+  const intersected = zones.filter(z => pathIntersectsZone(path, z));
+  return { path, intersected, explored: [] };
+}
+
+export default {
+  calculateAvoidingPath,
+  pathIntersectsZone,
+};

--- a/src/pathfinding.test.jsx
+++ b/src/pathfinding.test.jsx
@@ -1,70 +1,6 @@
-import { vi, describe, test, expect } from 'vitest';
-import { calculateAvoidingPath, pathIntersectsZone } from './App.jsx';
+import { describe, test, expect } from 'vitest';
 
-vi.mock('mapbox-gl', () => {
-  class Map {
-    constructor() {
-      this.doubleClickZoom = { disable() {} };
-    }
-    on() {}
-    remove() {}
-    getSource() {
-      return { setData() {} };
-    }
-    addSource() {}
-    addLayer() {}
-    fitBounds() {}
-    stop() {}
-    getStyle() {
-      return { layers: [] };
-    }
-    setTerrain() {}
-    removeLayer() {}
-    removeSource() {}
-    easeTo() {}
-    getCanvas() {
-      return { style: {} };
-    }
-    isStyleLoaded() {
-      return true;
-    }
-    getCenter() {
-      return { lng: 0, lat: 0 };
-    }
-    getZoom() {
-      return 0;
-    }
-    queryRenderedFeatures() {
-      return [];
-    }
-    off() {}
-  }
-  class Popup {
-    setLngLat() {
-      return this;
-    }
-    addTo() {
-      return this;
-    }
-    addClassName() {
-      return this;
-    }
-    setHTML() {
-      return this;
-    }
-    remove() {}
-  }
-  class Marker {
-    setLngLat() {
-      return this;
-    }
-    addTo() {
-      return this;
-    }
-    remove() {}
-  }
-  return { Map, Popup, Marker, default: { Map, Popup, Marker } };
-});
+import { calculateAvoidingPath, pathIntersectsZone } from './pathfinding.js';
 
 describe('pathIntersectsZone', () => {
   const polygon = {
@@ -142,5 +78,30 @@ describe('calculateAvoidingPath', () => {
     const { path } = calculateAvoidingPath(start, dest, [multipolygon]);
     expect(path.length).toBeGreaterThan(2);
     expect(pathIntersectsZone(path, multipolygon)).toBe(false);
+  });
+
+  test('handles adjacent zones with segment starting on a boundary', () => {
+    const zone1 = {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[0, 0],[0, 0.01],[0.01, 0.01],[0.01, 0],[0, 0]]]
+      }
+    };
+    const zone2 = {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[0.01, 0],[0.01, 0.01],[0.02, 0.01],[0.02, 0],[0.01, 0]]]
+      }
+    };
+    const start = [-0.005, 0.005];
+    const dest = [0.025, 0.005];
+
+    const { path } = calculateAvoidingPath(start, dest, [zone1, zone2]);
+    expect(pathIntersectsZone(path, zone1)).toBe(false);
+    expect(pathIntersectsZone(path, zone2)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- extract pathfinding helpers into dedicated module
- ensure avoidance algorithm re-runs until all zones are clear and handles segments starting inside a zone
- add regression test for adjacent zone boundaries

## Testing
- `npx vitest run` *(fails: process did not exit, likely due to environment limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68bf13108d0483288fe4de3cb93fdd2d