### PR TITLE
Show direct route vs avoiding distance

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -99,3 +99,26 @@ test('clearing a zone removes it from route', () => {
   expect(screen.queryByText('No Fly Zones')).toBeNull();
 });
 
+test('shows direct and avoiding distances', () => {
+  const selected = {
+    startLatitude: 0,
+    startLongitude: 0,
+    latitude: 1,
+    longitude: 1,
+  };
+  const path = [
+    [0, 0],
+    [0.5, 0.5],
+    [1, 1],
+  ];
+  render(
+    <App
+      initialSelected={selected}
+      initialFlightPath={path}
+      disableFocus={true}
+    />
+  );
+  expect(screen.getAllByText('Direct distance')[0]).toBeInTheDocument();
+  expect(screen.getAllByText('Avoiding distance')[0]).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- Compute and display both direct and NFZ-avoiding route distances in the flight info panel
- Highlight NFZs on the direct path as non-blocking and clearable for the current flight
- Add unit test covering direct and avoiding distance display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c00e4229d48328a55917dc27d57b1b