### PR TITLE
feat: show time on station in flight info

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,7 +25,8 @@ import {
   decimalMinutesToTime,
   getEstimatedMissionTimeAtWhichDroneShouldReturnInMinutes,
   getEstimatedCurrentCapacityConsumedAtWhichDroneShouldReturn,
-  getDistanceMeters
+  getDistanceMeters,
+  calculateTimeOnStation,
 } from './utils.js';
 
 mapboxgl.accessToken = 'pk.eyJ1Ijoic25pbGxvY21vdCIsImEiOiJjbThxY2U2MmIwYWE2MmtzOHhyNjdqMjZnIn0.3b-7Y5j4Uxy5kNCqcLaaYw';
@@ -172,6 +173,9 @@ export default function App(
     const returnTime = decimalMinutesToTime(
       getEstimatedMissionTimeAtWhichDroneShouldReturnInMinutes(distanceMeters)
     );
+    const timeOnStation = decimalMinutesToTime(
+      calculateTimeOnStation(distanceMeters)
+    );
     const directDistance =
       getDistanceMeters(startLat, startLng, destLat, destLng) / 1000;
     const directDistText = `${directDistance.toFixed(1)} km`;
@@ -180,6 +184,7 @@ export default function App(
       flight,
       returnCapacity,
       returnTime,
+      timeOnStation,
       directDistText,
       avoidDistText,
     };
@@ -1340,6 +1345,10 @@ export default function App(
                 )}
                 {flightInfo.returnCapacity.toFixed(2)} Ah
               </span>
+            </div>
+            <div className="info-row">
+              <span className="label">Time on station</span>
+              <span className="value">{flightInfo.timeOnStation}</span>
             </div>
             <div className="info-row">
               <span className="label">Return at mission time</span>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -122,3 +122,25 @@ test('shows direct and avoiding distances', () => {
   expect(screen.getAllByText('Avoiding distance')[0]).toBeInTheDocument();
 });
 
+test('shows time on station', () => {
+  const selected = {
+    startLatitude: 0,
+    startLongitude: 0,
+    latitude: 1,
+    longitude: 1,
+  };
+  const path = [
+    [0, 0],
+    [0.5, 0.5],
+    [1, 1],
+  ];
+  render(
+    <App
+      initialSelected={selected}
+      initialFlightPath={path}
+      disableFocus={true}
+    />
+  );
+  expect(screen.getAllByText('Time on station')[0]).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- include time-on-station calculation and display in flight info panel
- test that time on station appears in flight calculator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c162b7343c83288c557f4682993893