### PR TITLE
Rename layers to countries

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -88,7 +88,7 @@ test('clearing a zone removes it from route', () => {
   render(
     <App
       initialRouteNoFlyZones={[zone]}
-      initialLayerFeatures={{ test: [zone] }}
+      initialCountryFeatures={{ test: [zone] }}
       initialSelected={selected}
       initialFlightPath={path}
       disableFocus={true}

--- a/src/countries.test.jsx
+++ b/src/countries.test.jsx
@@ -48,9 +48,9 @@ vi.mock('mapbox-gl', () => {
   return { Map, Popup, Marker, default: { Map, Popup, Marker } };
 });
 
-test('layers are sorted by name', async () => {
+test('countries are sorted by name', async () => {
   const fetchMock = vi.fn(url => {
-    if (url.endsWith('/layers')) {
+    if (url.endsWith('/countries')) {
       return Promise.resolve({
         json: () => Promise.resolve([
           { id: 1, name: 'Bravo' },
@@ -73,14 +73,14 @@ test('layers are sorted by name', async () => {
   global.fetch = fetchMock;
 
   render(<App />);
-  const layersBtn = await screen.findByLabelText('Layers/No Fly Zones');
+  const countriesBtn = await screen.findByLabelText('Countries/No Fly Zones');
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://vectrabackyard-3dmb6.ondigitalocean.app/layers'
+      'https://vectrabackyard-3dmb6.ondigitalocean.app/countries'
     )
   );
-  fireEvent.click(layersBtn);
-  const dialog = screen.getByText('Layers').parentElement;
+  fireEvent.click(countriesBtn);
+  const dialog = screen.getByText('Countries').parentElement;
   const buttons = within(dialog).getAllByRole('button');
   expect(buttons.map(b => b.textContent)).toEqual(['Alpha', 'Bravo']);
 });

--- a/src/style.css
+++ b/src/style.css
@@ -830,22 +830,22 @@ body.light .nfz-popup-nav button {
   }
 }
 
-.layers-overlay {
+.countries-overlay {
   animation: fadeInUp 0.3s ease;
 }
 
-.layers-overlay ul {
+.countries-overlay ul {
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.layers-overlay button {
+.countries-overlay button {
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
-.layers-overlay .layer-name {
+.countries-overlay .country-name {
   flex: 1;
 }


### PR DESCRIPTION
## Summary
- Replace "layers" terminology with "countries" across UI and logic
- Adjust styles and tests for countries overlay and data fetching

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68c1646580948328beceb816da26b97f