### PR TITLE
Show avoiding distance only for no-fly zones

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1319,17 +1319,19 @@ export default function App(
               <span className="label">Direct distance</span>
               <span className="value">{flightInfo.directDistText}</span>
             </div>
-            <div className="info-row">
-              <span className="label">Avoiding distance</span>
-              <span className={`value ${flightInfo.flight.outboundCapacityCheck ? 'ok' : 'no'}`}>
-                {flightInfo.flight.outboundCapacityCheck ? (
-                  <SealCheck size={16} weight="fill" />
-                ) : (
-                  <SealWarning size={16} weight="fill" />
-                )}
-                {flightInfo.avoidDistText}
-              </span>
-            </div>
+            {routeNoFlyZones.length > 0 && (
+              <div className="info-row">
+                <span className="label">Avoiding distance</span>
+                <span className={`value ${flightInfo.flight.outboundCapacityCheck ? 'ok' : 'no'}`}>
+                  {flightInfo.flight.outboundCapacityCheck ? (
+                    <SealCheck size={16} weight="fill" />
+                  ) : (
+                    <SealWarning size={16} weight="fill" />
+                  )}
+                  {flightInfo.avoidDistText}
+                </span>
+              </div>
+            )}
             <div className="info-row">
               <span className="label">Return Capacity</span>
               <span className={`value ${flightInfo.flight.returnCapacityCheck ? 'ok' : 'no'}`}>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -99,7 +99,34 @@ test('clearing a zone removes it from route', () => {
   expect(screen.queryByText('No Fly Zones')).toBeNull();
 });
 
-test('shows direct and avoiding distances', () => {
+test('hides avoiding distance when there are no no-fly zones', () => {
+  const selected = {
+    startLatitude: 0,
+    startLongitude: 0,
+    latitude: 1,
+    longitude: 1,
+  };
+  const path = [
+    [0, 0],
+    [1, 1],
+  ];
+  render(
+    <App
+      initialSelected={selected}
+      initialFlightPath={path}
+      disableFocus={true}
+    />
+  );
+  expect(screen.getAllByText('Direct distance')[0]).toBeInTheDocument();
+  expect(screen.queryByText('Avoiding distance')).toBeNull();
+});
+
+test('shows avoiding distance when there is a no-fly zone', () => {
+  const zone = {
+    type: 'Feature',
+    properties: { id: 'zone-1', name: 'Test Zone' },
+    geometry: { type: 'Polygon', coordinates: [[[0, 0],[0, 1],[1, 1],[1, 0],[0, 0]]] }
+  };
   const selected = {
     startLatitude: 0,
     startLongitude: 0,
@@ -115,6 +142,7 @@ test('shows direct and avoiding distances', () => {
     <App
       initialSelected={selected}
       initialFlightPath={path}
+      initialRouteNoFlyZones={[zone]}
       disableFocus={true}
     />
   );


### PR DESCRIPTION
## Summary
- Hide avoiding distance when there are no route no-fly zones
- Test avoiding distance visibility with and without no-fly zones

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c1632103f48328a60922303e1c39d3