### PR TITLE
feat: add navigation to flight settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1376,6 +1376,19 @@ export default function App(
             </div>
           </div>
 
+          <p className="info-hint">
+            Double click on the map to set a different destination.
+          </p>
+          <button
+            className="back-link"
+            onClick={() => {
+              resetMission();
+              setShowDialog(true);
+            }}
+          >
+            Back to flight settings
+          </button>
+
           {routeNoFlyZones.length > 0 && (
             <div className="nfz-clearance">
               <h4>No Fly Zones</h4>

--- a/src/style.css
+++ b/src/style.css
@@ -571,6 +571,16 @@ body.light .manual-entry button:hover:not(:disabled) {
   font-size: 14px;
 }
 
+.info-hint {
+  font-size: 12px;
+  margin: 4px 0;
+  color: #ccc;
+}
+
+body.light .info-hint {
+  color: #555;
+}
+
 .info-panel h3 {
   margin: 0 0 12px 0;
   color: #bbb;


### PR DESCRIPTION
## Summary
- prompt pilots that a double click resets the destination
- add link to reopen flight settings and reset mission
- style hint text for light and dark themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1630b21ac8328b98e589fdf5ce8b2