### PR TITLE
Use layers endpoint for country data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -575,22 +575,22 @@ export default function App(
   }, [showWeather, mapLoaded]);
 
 
-  // load countries
+  // load layers
   useEffect(() => {
     if (!mapLoaded) return;
-    async function loadCountries() {
+    async function loadLayers() {
       try {
-        const res = await fetch('https://vectrabackyard-3dmb6.ondigitalocean.app/countries');
+        const res = await fetch('https://vectrabackyard-3dmb6.ondigitalocean.app/layers');
         const data = await res.json();
         const sorted = [...data].sort((a, b) =>
           (a.name || a.title || '').localeCompare(b.name || b.title || '')
         );
         setCountries(sorted);
       } catch (e) {
-        console.error('Failed to load countries', e);
+        console.error('Failed to load layers', e);
       }
     }
-    loadCountries();
+    loadLayers();
   }, [mapLoaded]);
 
   function clearOverlays(options = {}) {
@@ -936,14 +936,14 @@ export default function App(
     }
 
     try {
-      const res = await fetch(`https://vectrabackyard-3dmb6.ondigitalocean.app/countries/${id}`);
+      const res = await fetch(`https://vectrabackyard-3dmb6.ondigitalocean.app/layers/${id}`);
       const countryDetails = await res.json();
       let features;
       try {
         const firstParse = JSON.parse(countryDetails.content);
         features = Array.isArray(firstParse) ? firstParse : JSON.parse(firstParse);
       } catch (e) {
-        console.error('Failed to parse country GeoJSON', e);
+        console.error('Failed to parse layer GeoJSON', e);
         return;
       }
       const filtered = features
@@ -1192,7 +1192,7 @@ export default function App(
       };
       setSelectedCountryId(id);
     } catch (e) {
-      console.error('Failed to load country', e);
+      console.error('Failed to load layer', e);
     }
   }
   function setManualRoute(startLat, startLng, destLat, destLng) {

--- a/src/countries.test.jsx
+++ b/src/countries.test.jsx
@@ -48,9 +48,9 @@ vi.mock('mapbox-gl', () => {
   return { Map, Popup, Marker, default: { Map, Popup, Marker } };
 });
 
-test('countries are sorted by name', async () => {
+test('layers are sorted by name', async () => {
   const fetchMock = vi.fn(url => {
-    if (url.endsWith('/countries')) {
+    if (url.endsWith('/layers')) {
       return Promise.resolve({
         json: () => Promise.resolve([
           { id: 1, name: 'Bravo' },
@@ -76,7 +76,7 @@ test('countries are sorted by name', async () => {
   const countriesBtn = await screen.findByLabelText('Countries/No Fly Zones');
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://vectrabackyard-3dmb6.ondigitalocean.app/countries'
+      'https://vectrabackyard-3dmb6.ondigitalocean.app/layers'
     )
   );
   fireEvent.click(countriesBtn);


### PR DESCRIPTION
## Summary
- Fetch layer list from `/layers` instead of `/countries`
- Retrieve layer details via `/layers/:id` and update error logs
- Adjust tests to expect layer-based API calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c167d849a883288ba47aa87732c5b0