### PR TITLE
Add welcome dialog and tutorial overlay

### DIFF
--- a/src/TutorialOverlay.jsx
+++ b/src/TutorialOverlay.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+
+export default function TutorialOverlay({ steps, stepIndex, onNext, onPrev, onClose }) {
+  const [rect, setRect] = useState(null);
+  const step = steps[stepIndex];
+
+  useEffect(() => {
+    const el = document.querySelector(step.selector);
+    if (el) {
+      setRect(el.getBoundingClientRect());
+    } else {
+      setRect(null);
+    }
+  }, [step, stepIndex]);
+
+  useEffect(() => {
+    function handleKey(e) {
+      const key = e.key.toLowerCase();
+      if (key === 'escape') {
+        onClose();
+      } else if (key === 'n') {
+        onNext();
+      } else if (key === 'p') {
+        onPrev();
+      }
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onNext, onPrev, onClose]);
+
+  if (!rect) return null;
+
+  const isLast = stepIndex === steps.length - 1;
+
+  return (
+    <div className="tutorial-overlay">
+      <div
+        className="tutorial-highlight"
+        style={{ top: rect.top, left: rect.left, width: rect.width, height: rect.height }}
+      />
+      <div className="tutorial-tooltip glass-effect" style={{ top: rect.bottom + 10, left: rect.left }}>
+        <p>{step.text}</p>
+        <div className="tutorial-buttons">
+          <button onClick={onClose}>Cancel (Esc)</button>
+          <button onClick={onPrev} disabled={stepIndex === 0}>
+            Previous (P)
+          </button>
+          <button onClick={onNext}>{isLast ? 'Finish' : 'Next (N)'}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/WelcomeDialog.jsx
+++ b/src/WelcomeDialog.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+export default function WelcomeDialog({ onShowTutorial, onClose }) {
+  const [dontShow, setDontShow] = useState(false);
+
+  return (
+    <div className="welcome-overlay">
+      <div className="welcome-dialog glass-effect">
+        <img src="/favicon.svg" alt="Vectra logo" className="welcome-logo" />
+        <h2>Welcome to Vectra</h2>
+        <p>Plan and visualize your drone missions.</p>
+        <label className="welcome-checkbox">
+          <input
+            type="checkbox"
+            checked={dontShow}
+            onChange={e => setDontShow(e.target.checked)}
+          />
+          Don't show this again
+        </label>
+        <div className="welcome-buttons">
+          <button onClick={() => onShowTutorial(dontShow)}>Show Tutorial</button>
+          <button onClick={() => onClose(dontShow)}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -906,3 +906,85 @@ body.light .nfz-popup-nav button {
 .countries-overlay .country-name {
   flex: 1;
 }
+
+.welcome-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.welcome-dialog {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 20px;
+  border-radius: 8px;
+  width: 280px;
+  color: #fff;
+}
+
+.welcome-logo {
+  width: 48px;
+  height: 48px;
+}
+
+.welcome-buttons {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.welcome-checkbox {
+  align-self: flex-start;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tutorial-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 150;
+}
+
+.tutorial-highlight {
+  position: absolute;
+  border: 2px solid #f7931e;
+  border-radius: 4px;
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
+.tutorial-tooltip {
+  position: absolute;
+  max-width: 300px;
+  padding: 10px;
+  border-radius: 8px;
+  color: #fff;
+  pointer-events: auto;
+}
+
+body.light .tutorial-tooltip {
+  color: #000;
+}
+
+.tutorial-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}


### PR DESCRIPTION
## Summary
- show a welcome modal with Vectra logo, tutorial button and "don't show again" option
- implement step-based tutorial overlay with keyboard navigation
- add styles for onboarding dialog and tutorial highlighting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c285a0bfa883288e10ef0d43bafae7