### PR TITLE
Center welcome dialog content and use updated icon

### DIFF
--- a/src/WelcomeDialog.jsx
+++ b/src/WelcomeDialog.jsx
@@ -6,7 +6,7 @@ export default function WelcomeDialog({ onShowTutorial, onClose }) {
   return (
     <div className="welcome-overlay">
       <div className="welcome-dialog glass-effect">
-        <img src="/favicon.svg" alt="Vectra logo" className="welcome-logo" />
+        <img src="/images/favi2.png" alt="Vectra logo" className="welcome-logo" />
         <h2>Welcome to Vectra</h2>
         <p>Plan and visualize your drone missions.</p>
         <label className="welcome-checkbox">

--- a/src/style.css
+++ b/src/style.css
@@ -924,6 +924,7 @@ body.light .nfz-popup-nav button {
   display: flex;
   flex-direction: column;
   align-items: center;
+  text-align: center;
   gap: 10px;
   padding: 20px;
   border-radius: 8px;
@@ -939,16 +940,25 @@ body.light .nfz-popup-nav button {
 .welcome-buttons {
   display: flex;
   gap: 8px;
-  justify-content: flex-end;
+  justify-content: center;
   width: 100%;
 }
 
+.welcome-buttons button {
+  background: #f7931e;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
 .welcome-checkbox {
-  align-self: flex-start;
   font-size: 14px;
   display: flex;
   align-items: center;
   gap: 6px;
+  justify-content: center;
+  width: 100%;
 }
 
 .tutorial-overlay {


### PR DESCRIPTION
## Summary
- Center align welcome dialog text and controls
- Replace welcome icon with `favi2` and style buttons to match app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c29baec53883288d56c5795e9c5111