### PR TITLE
Fix NFZ layer visibility state persistence

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -954,6 +954,11 @@ export default function App(
       delete countryFeaturesRef.current[selectedCountryId];
       setCountryFeatures(Object.values(countryFeaturesRef.current).flat());
       setSelectedCountryId(null);
+      try {
+        localStorage.removeItem('selectedCountryId');
+      } catch (e) {
+        console.error('Failed to remove saved country id', e);
+      }
     }
     if (selectedCountryId === id) {
       if (map.getLayer(fillId)) map.removeLayer(fillId);
@@ -969,6 +974,11 @@ export default function App(
       delete countryFeaturesRef.current[id];
       setCountryFeatures(Object.values(countryFeaturesRef.current).flat());
       setSelectedCountryId(null);
+      try {
+        localStorage.removeItem('selectedCountryId');
+      } catch (e) {
+        console.error('Failed to remove saved country id', e);
+      }
       return;
     }
 
@@ -1228,6 +1238,11 @@ export default function App(
         mouseleave: mouseLeaveHandler
       };
       setSelectedCountryId(id);
+      try {
+        localStorage.setItem('selectedCountryId', id);
+      } catch (e) {
+        console.error('Failed to save country id', e);
+      }
     } catch (e) {
       console.error('Failed to load layer', e);
     }


### PR DESCRIPTION
## Summary
- Update `toggleCountry` to immediately sync `selectedCountryId` with `localStorage`
- Prevents no-fly zone layers from reappearing after a refresh when the layer was hidden

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c29df7e30c8328b48e3eca8c36eb45