### PR TITLE
Refine top-right controls and tutorial buttons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1298,8 +1298,8 @@ export default function App(
         <button
           className="glass-effect"
           onClick={cycleMapStyle}
-          aria-label="Map type"
-          title="Map type"
+          aria-label="Change map style"
+          title="Change map style"
         >
           <NextIcon size={18} />
         </button>
@@ -1307,8 +1307,8 @@ export default function App(
           <button
             className="kp-pill glass-effect"
             disabled
-            aria-label="Geomagnetic activity (Pro only)"
-            title="Geomagnetic activity (Pro only)"
+            aria-label="View geomagnetic activity (Pro only)"
+            title="View geomagnetic activity (Pro only)"
           >
             kp
             <span className="pro-tag">Pro</span>
@@ -1317,8 +1317,8 @@ export default function App(
         <button
           className="btn-3d glass-effect"
           disabled
-          aria-label="Camera mode (Pro only)"
-          title="Camera mode (Pro only)"
+          aria-label="Toggle 3D camera (Pro only)"
+          title="Toggle 3D camera (Pro only)"
         >
           3D
           <span className="pro-tag">Pro</span>
@@ -1326,23 +1326,23 @@ export default function App(
         <button
           className="glass-effect"
           onClick={rotateMap}
-          aria-label="Rotate camera"
-          title="Rotate camera"
+          aria-label="Rotate view"
+          title="Rotate view"
         >
           <ArrowClockwise size={18} />
         </button>
         <button
           className="glass-effect"
           onClick={toggleFlights}
-          aria-label="Flights"
-          title="Flights"
+          aria-label="Open flights panel"
+          title="Open flights panel"
         >
           <Airplane size={18} />
         </button>
         <button
           className="glass-effect"
-          aria-label="Weather (Pro only)"
-          title="Weather (Pro only)"
+          aria-label="View weather (Pro only)"
+          title="View weather (Pro only)"
           disabled
         >
           <Cloud size={18} />
@@ -1351,8 +1351,8 @@ export default function App(
         <button
           className="glass-effect"
           onClick={toggleCountries}
-          aria-label="Countries/No Fly Zones"
-          title="Countries/No Fly Zones"
+          aria-label="Toggle countries and no-fly zones"
+          title="Toggle countries and no-fly zones"
         >
           <Stack size={18} />
         </button>
@@ -1360,7 +1360,8 @@ export default function App(
         <button
           className="glass-effect"
           onClick={toggleFeedback}
-          aria-label="Feedback"
+          aria-label="Send feedback"
+          title="Send feedback"
         >
           <ChatCenteredText size={18} />
         </button>

--- a/src/TutorialOverlay.jsx
+++ b/src/TutorialOverlay.jsx
@@ -41,11 +41,25 @@ export default function TutorialOverlay({ steps, stepIndex, onNext, onPrev, onCl
       <div className="tutorial-tooltip glass-effect" style={{ top: rect.bottom + 10, left: rect.left }}>
         <p>{step.text}</p>
         <div className="tutorial-buttons">
-          <button onClick={onClose}>Cancel (Esc)</button>
-          <button onClick={onPrev} disabled={stepIndex === 0}>
-            Previous (P)
+          <button className="secondary-btn" onClick={onClose}>
+            Cancel<kbd>Esc</kbd>
           </button>
-          <button onClick={onNext}>{isLast ? 'Finish' : 'Next (N)'}</button>
+          <button
+            className="secondary-btn"
+            onClick={onPrev}
+            disabled={stepIndex === 0}
+          >
+            Previous<kbd>P</kbd>
+          </button>
+          <button className="primary-btn" onClick={onNext}>
+            {isLast ? (
+              'Finish'
+            ) : (
+              <>
+                Next<kbd>N</kbd>
+              </>
+            )}
+          </button>
         </div>
       </div>
     </div>

--- a/src/WelcomeDialog.jsx
+++ b/src/WelcomeDialog.jsx
@@ -18,8 +18,12 @@ export default function WelcomeDialog({ onShowTutorial, onClose }) {
           Don't show this again
         </label>
         <div className="welcome-buttons">
-          <button onClick={() => onShowTutorial(dontShow)}>Show Tutorial</button>
-          <button onClick={() => onClose(dontShow)}>Close</button>
+          <button className="primary-btn" onClick={() => onShowTutorial(dontShow)}>
+            Show Tutorial
+          </button>
+          <button className="secondary-btn" onClick={() => onClose(dontShow)}>
+            Close
+          </button>
         </div>
       </div>
     </div>

--- a/src/countries.test.jsx
+++ b/src/countries.test.jsx
@@ -73,7 +73,7 @@ test('layers are sorted by name', async () => {
   global.fetch = fetchMock;
 
   render(<App />);
-  const countriesBtn = await screen.findByLabelText('Countries/No Fly Zones');
+  const countriesBtn = await screen.findByLabelText('Toggle countries and no-fly zones');
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(
       'https://vectrabackyard-3dmb6.ondigitalocean.app/layers'

--- a/src/style.css
+++ b/src/style.css
@@ -945,7 +945,6 @@ body.light .nfz-popup-nav button {
 }
 
 .welcome-buttons button {
-  background: #f7931e;
   border: none;
   padding: 8px 12px;
   border-radius: 4px;
@@ -997,4 +996,42 @@ body.light .tutorial-tooltip {
   justify-content: flex-end;
   gap: 8px;
   margin-top: 8px;
+}
+
+.primary-btn,
+.secondary-btn {
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primary-btn {
+  background: #f7931e;
+  color: #000;
+}
+
+.secondary-btn {
+  background: #555;
+  color: #fff;
+}
+
+body.light .secondary-btn {
+  background: #ddd;
+  color: #000;
+}
+
+kbd {
+  background: #333;
+  color: #fff;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: 12px;
+  font-family: monospace;
+  margin-left: 4px;
+}
+
+body.light kbd {
+  background: #eee;
+  color: #000;
 }


### PR DESCRIPTION
## Summary
- add descriptive titles for all top-right map control buttons and mark pro-only features
- style welcome dialog close button with secondary color
- redesign tutorial overlay controls with color-coded buttons and keyboard shortcut icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2a621c3fc8328902f2fedf1a9d51e