### PR TITLE
Recalculate flight path after clearing NFZ

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -904,9 +904,8 @@ export default function App(
     if (selected) {
       if (!disableFocus) {
         focusDestination(selected, newCleared);
-      } else {
-        recalcFlightPath();
       }
+      recalcFlightPath();
     } else {
       setPathNoGo(remaining.length > 0);
     }


### PR DESCRIPTION
## Summary
- ensure clearing a no-fly zone triggers flight path recalculation so the route redraws immediately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2d81f27d48328a3983c3affda62d3