### PR TITLE
Add Google Analytics tracking snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,17 @@
       href="https://fonts.googleapis.com/css2?family=Geist&display=swap"
       rel="stylesheet"
     />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RT9HZYD1X5"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-RT9HZYD1X5");
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- embed the Google Analytics gtag.js snippet in the main HTML head to enable tracking

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd30d55180832891f14476d44a74fc